### PR TITLE
feat: add plugin for gum

### DIFF
--- a/gum/README.md
+++ b/gum/README.md
@@ -1,0 +1,21 @@
+# gum plugin
+
+[gum](https://github.com/charmbracelet/gum) plugin for [proto](https://github.com/moonrepo/proto).
+
+## Installation
+
+This is a community plugin and is thus not built-in to proto. In order to use it, first either add it to your global or project-based `.prototools` by running:
+
+### Global install
+
+```shell
+proto plugin add gum "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gum/plugin.toml" --global
+proto install gum
+```
+
+### Per-project install
+
+```shell
+proto plugin add gum "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gum/plugin.toml"
+proto pin gum latest --resolve
+```

--- a/gum/plugin.test.ts
+++ b/gum/plugin.test.ts
@@ -1,0 +1,8 @@
+import { run } from "../testkit.js";
+
+run({
+	name: "gum",
+	afterInstall: async ($) => {
+		await $`gum -v`;
+	},
+});

--- a/gum/plugin.toml
+++ b/gum/plugin.toml
@@ -1,0 +1,32 @@
+# A TOML plugin for gum:
+# https://moonrepo.dev/docs/proto/plugins#toml-plugin
+
+name = "gum"
+type = "cli"
+
+[platform.linux]
+bin-path = "gum_{version}_Linux_{arch}/gum"
+download-file = "gum_{version}_Linux_{arch}.tar.gz"
+checksum-file = "checksums.txt"
+
+[platform.macos]
+bin-path = "gum_{version}_Darwin_{arch}/gum"
+download-file = "gum_{version}_Darwin_{arch}.tar.gz"
+checksum-file = "checksums.txt"
+
+[platform.windows]
+bin-path = "gum_{version}_Windows_{arch}/gum.exe"
+download-file = "gum_{version}_Windows_{arch}.zip"
+checksum-file = "checksums.txt"
+
+[install]
+download-url = "https://github.com/charmbracelet/gum/releases/download/v{version}/{download_file}"
+checksum-url = "https://github.com/charmbracelet/gum/releases/download/v{version}/{checksum_file}"
+
+[install.arch]
+aarch64 = "arm64"
+x86_64 = "x86_64"
+x86 = "i386"
+
+[resolve]
+git-url = "https://github.com/charmbracelet/gum"


### PR DESCRIPTION
gumがv0.10.0からパッケージングの仕方が変わり、以下のpluginが壊れた為、v0.10.0以降版のpluginをこちらに作成します.
https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/gum/plugin.toml