### PR TITLE
feat: add sentry-cli

### DIFF
--- a/sentry-cli/README.md
+++ b/sentry-cli/README.md
@@ -1,0 +1,21 @@
+# GitHub CLI plugin
+
+[Sentry CLI](https://github.com/getsentry/sentry-cli) plugin for [proto](https://github.com/moonrepo/proto).
+
+## Installation
+
+This is a community plugin and is thus not built-in to proto. In order to use it, first either add it to your global or project-based `.prototools` by running:
+
+### Global install
+
+```shell
+proto plugin add sentry-cli "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/sentry-cli/plugin.toml" --global
+proto install sentry-cli
+```
+
+### Per-project install
+
+```shell
+proto plugin add gh "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/sentry-cli/plugin.toml"
+proto pin sentry-cli latest --resolve
+```

--- a/sentry-cli/plugin.test.ts
+++ b/sentry-cli/plugin.test.ts
@@ -1,0 +1,8 @@
+import { run } from "../testkit.js";
+
+run({
+  name: "sentry-cli",
+  afterInstall: async ($) => {
+    await $`sentry-cli -V`;
+  },
+});

--- a/sentry-cli/plugin.toml
+++ b/sentry-cli/plugin.toml
@@ -1,0 +1,29 @@
+# A TOML plugin for sentry-cli:
+# https://moonrepo.dev/docs/proto/plugins#toml-plugin
+
+name = "sentry-cli"
+type = "cli"
+
+[resolve]
+git-url = "https://github.com/getsentry/sentry-cli"
+
+[platform.linux]
+bin-path = "sentry-cli-Linux-{arch}"
+download-file = "sentry-cli-linux-{arch}-2.32.2.tgz"
+
+[platform.macos]
+bin-path = "sentry-cli-Darwin-{arch}"
+download-file = "sentry-cli-Darwin-{arch}"
+
+[platform.windows]
+bin-path = "sentry-cli-Windows-{arch}.exe"
+download-file = "sentry-cli-Windows-{arch}.exe"
+
+[install]
+download-url = "https://github.com/getsentry/sentry-cli/releases/download/{version}/{download_file}"
+
+[install.arch]
+arm = "arm"
+arm64 = "arm64"
+x86 = "x86"
+x86_64 = "x86_64"


### PR DESCRIPTION
Tests fail, but I think its mostly right - the architectures don't line up with their sources 1-1

https://github.com/getsentry/sentry-cli/releases/ 