### PR TITLE
feat: add plugin for OpenTofu

### DIFF
--- a/tofu/README.md
+++ b/tofu/README.md
@@ -1,0 +1,21 @@
+# OpenTofu plugin
+
+[OpenTofu](https://opentofu.org/) plugin for [proto](https://github.com/moonrepo/proto).
+
+## Installation
+
+This is a community plugin and is thus not built-in to proto. In order to use it, first either add it to your global or project-based `.prototools` by running:
+
+### Global install
+
+```shell
+proto plugin add tofu "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/tofu/plugin.toml" --global
+proto install tofu
+```
+
+### Per-project install
+
+```shell
+proto plugin add tofu "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/tofu/plugin.toml"
+proto pin tofu latest --resolve
+```

--- a/tofu/plugin.test.ts
+++ b/tofu/plugin.test.ts
@@ -1,0 +1,8 @@
+import { run } from "../testkit.js";
+
+run({
+	name: "tofu",
+	afterInstall: async ($) => {
+		await $`tofu --version`;
+	},
+});

--- a/tofu/plugin.toml
+++ b/tofu/plugin.toml
@@ -1,0 +1,44 @@
+# A TOML plugin for OpenTofu:
+# https://moonrepo.dev/docs/proto/toml-plugin
+
+name = "OpenTofu"
+type = "cli"
+
+[platform.linux]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_{os}_{arch}.tar.gz"
+
+[platform.macos]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_darwin_{arch}.tar.gz"
+
+[platform.freebsd]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_{os}_{arch}.tar.gz"
+
+[platform.openbsd]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_{os}_{arch}.tar.gz"
+
+[platform.solaris]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_{os}_{arch}.tar.gz"
+
+[platform.windows]
+checksum-file = "tofu_{version}_SHA256SUMS"
+download-file = "tofu_{version}_{os}_{arch}.tar.gz"
+
+[install]
+checksum-url = "https://github.com/opentofu/opentofu/releases/download/v{version}/{checksum_file}"
+download-url = "https://github.com/opentofu/opentofu/releases/download/v{version}/{download_file}"
+
+[install.arch]
+x86 = "386"
+x86_64 = "amd64"
+aarch64 = "arm64"
+
+[resolve]
+git-url = "https://github.com/opentofu/opentofu"
+
+[detect]
+version-files = [".opentofu-version"]


### PR DESCRIPTION
I added a plugin for [OpenTofu](https://opentofu.org/), the open source infrastructure as code tool. The test I created for the new plugin is working, but some other tests (of other plugins) fail.