### PR TITLE
feat: add plugin for Ruff

### DIFF
--- a/ruff/README.md
+++ b/ruff/README.md
@@ -1,0 +1,21 @@
+# OpenTofu plugin
+
+[Ruff](https://docs.astral.sh/ruff/) plugin for [proto](https://github.com/moonrepo/proto).
+
+## Installation
+
+This is a community plugin and is thus not built-in to proto. In order to use it, first either add it to your global or project-based `.prototools` by running:
+
+### Global install
+
+```shell
+proto plugin add ruff "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/ruff/plugin.toml" --global
+proto install ruff
+```
+
+### Per-project install
+
+```shell
+proto plugin add ruff "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/ruff/plugin.toml"
+proto pin ruff latest --resolve
+```

--- a/ruff/plugin.test.ts
+++ b/ruff/plugin.test.ts
@@ -1,0 +1,8 @@
+import { run } from "../testkit.js";
+
+run({
+	name: "ruff",
+	afterInstall: async ($) => {
+		await $`ruff --version`;
+	},
+});

--- a/ruff/plugin.toml
+++ b/ruff/plugin.toml
@@ -1,0 +1,26 @@
+name = "Ruff"
+type = "cli"
+
+[resolve]
+git-url = "https://github.com/astral-sh/ruff"
+
+[platform.linux]
+download-file = "ruff-{arch}-unknown-linux-{libc}.tar.gz"
+checksum-file = "ruff-{arch}-unknown-linux-{libc}.tar.gz.sha256"
+archive-prefix = "ruff-{arch}-unknown-linux-{libc}"
+
+[platform.macos]
+download-file = "ruff-{arch}-apple-darwin.tar.gz"
+checksum-file = "ruff-{arch}-apple-darwin.tar.gz.sha256"
+archive-prefix = "ruff-{arch}-apple-darwin"
+
+[platform.windows]
+download-file = "ruff-{arch}-pc-windows-msvc.zip"
+checksum-file = "ruff-{arch}-pc-windows-msvc.zip.sha256"
+
+[install]
+download-url = "https://github.com/astral-sh/ruff/releases/download/{version}/{download_file}"
+checksum-url = "https://github.com/astral-sh/ruff/releases/download/{version}/{checksum_file}"
+
+[install.arch]
+x86 = "i686"


### PR DESCRIPTION
Hello again. I added a plugin for [Ruff](https://docs.astral.sh/ruff/), an extremely fast Python linter and code formatter, written in Rust. The test I created for the new plugin is working, but some other tests (of other plugins) fail.