### PR TITLE
feat: add plugin for Trivy

### DIFF
--- a/trivy/README.md
+++ b/trivy/README.md
@@ -1,0 +1,21 @@
+# Trivy plugin
+
+[Trivy](https://aquasecurity.github.io/trivy) plugin for [proto](https://github.com/moonrepo/proto).
+
+## Installation
+
+This is a community plugin and is thus not built-in to proto. In order to use it, first either add it to your global or project-based `.prototools` by running:
+
+### Global install
+
+```shell
+proto plugin add trivy "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/trivy/plugin.toml" --global
+proto install trivy
+```
+
+### Per-project install
+
+```shell
+proto plugin add trivy "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/trivy/plugin.toml"
+proto pin trivy latest --resolve
+```

--- a/trivy/plugin.test.ts
+++ b/trivy/plugin.test.ts
@@ -1,0 +1,8 @@
+import { run } from "../testkit.js";
+
+run({
+	name: "trivy",
+	afterInstall: async ($) => {
+		await $`trivy --version`;
+	},
+});

--- a/trivy/plugin.toml
+++ b/trivy/plugin.toml
@@ -1,0 +1,27 @@
+# A TOML plugin for Trivy:
+# https://moonrepo.dev/docs/proto/toml-plugin
+
+name = "Trivy"
+type = "cli"
+
+[platform.freebsd]
+download-file = "trivy_{version}_FreeBSD-{arch}.tar.gz"
+
+[platform.linux]
+download-file = "trivy_{version}_Linux-{arch}.tar.gz"
+
+[platform.macos]
+download-file = "trivy_{version}_macOS-{arch}.tar.gz"
+
+[install]
+checksum-url = "https://github.com/aquasecurity/trivy/releases/download/v{version}/trivy_{version}_checksums.txt"
+download-url = "https://github.com/aquasecurity/trivy/releases/download/v{version}/{download_file}"
+
+[install.arch]
+x86 = "36bit"
+x86_64 = "64bit"
+arm = "ARM"
+aarch64 = "ARM64"
+
+[resolve]
+git-url = "https://github.com/aquasecurity/trivy"


### PR DESCRIPTION
Hello again. I added a plugin for [Trivy](https://aquasecurity.github.io/trivy), a comprehensive and versatile security scanner. The test I created for the new plugin is working, but some other test (of another plugin) fails.