### PR TITLE
Update fzf urls

### DIFF
--- a/fzf/README.md
+++ b/fzf/README.md
@@ -19,3 +19,12 @@ proto install fzf
 proto plugin add fzf "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/fzf/plugin.toml"
 proto pin fzf latest --resolve
 ```
+
+## Installing versions before 0.54
+
+fzf had its URLs changed with version 0.54, so this plugin was updated accordingly to allow installing the latest versions of fzf. To install versions 0.53 and older of fzf with proto, you have to use an older version of this plugin:
+
+```shell
+proto plugin add fzf "source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/a94ea8ffa8cdcadf4206e50385d8910a27b1cbff/fzf/plugin.toml"
+proto pin fzf 0.53.0
+```

--- a/fzf/plugin.toml
+++ b/fzf/plugin.toml
@@ -17,7 +17,7 @@ download-file = "fzf-{version}-windows_{arch}.zip"
 checksum-file = "fzf_{version}_checksums.txt"
 
 [install]
-download-url = "https://github.com/junegunn/fzf/releases/download/{version}/{download_file}"
+download-url = "https://github.com/junegunn/fzf/releases/download/v{version}/{download_file}"
 
 [install.arch]
 aarch64 = "arm64"


### PR DESCRIPTION
I updated fzf URLs to include the v-prefix, allowing installs of the latest version of fzf. Also, I added documentation on how to install older versions of fzf with proto using GitHub permalinks. Resolves #27.