### PR TITLE
Fix sentry cli plugin

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,8 +1,8 @@
-gh = "2.51.0"
-just = "1.29.1"
-moon = "1.25.6"
-node = "22.3.0"
-rust = "1.79.0"
+gh = "2.67.0"
+just = "1.39.0"
+moon = "1.32.7"
+node = "22.14.0"
+rust = "1.85.0"
 
 [plugins]
 gh = "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gh/plugin.toml"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 	},
 	"packageManager": "yarn@4.2.2",
 	"engines": {
-		"node": "22.3.0"
+		"node": "22.14.0"
 	}
 }

--- a/sentry-cli/plugin.toml
+++ b/sentry-cli/plugin.toml
@@ -8,22 +8,17 @@ type = "cli"
 git-url = "https://github.com/getsentry/sentry-cli"
 
 [platform.linux]
-bin-path = "sentry-cli-Linux-{arch}"
-download-file = "sentry-cli-linux-{arch}-2.32.2.tgz"
+download-file = "sentry-cli-linux-{arch}"
 
 [platform.macos]
-bin-path = "sentry-cli-Darwin-{arch}"
-download-file = "sentry-cli-Darwin-{arch}"
+download-file = "sentry-cli-Darwin-universal"
 
 [platform.windows]
-bin-path = "sentry-cli-Windows-{arch}.exe"
 download-file = "sentry-cli-Windows-{arch}.exe"
 
 [install]
 download-url = "https://github.com/getsentry/sentry-cli/releases/download/{version}/{download_file}"
 
 [install.arch]
-arm = "arm"
-arm64 = "arm64"
-x86 = "x86"
-x86_64 = "x86_64"
+x86 = "i686"
+aarch64 = "arm64"


### PR DESCRIPTION
Hello there, I was about to add some plugins - but had to fix sentry-cli plugin first. Had to fix download URLs, but the test would only turn green when I also updated all the tools (.prototools and package.json).