### PR TITLE
fix(mise): fix winodws download file name

### DIFF
--- a/mise/plugin.toml
+++ b/mise/plugin.toml
@@ -13,7 +13,7 @@ download-file = "mise-v{version}-macos-{arch}"
 checksum-file = "SHASUMS256.txt"
 
 [platform.windows]
-download-file = "mise-v{version}-win-{arch}.zip"
+download-file = "mise-v{version}-windows-{arch}.zip"
 checksum-file = "SHASUMS256.txt"
 exe-path = "bin/mise.exe"
 


### PR DESCRIPTION
Downloads now seem to be named "windows" instead of "win". Recommend updating to allow tool to install. 

Reference: https://github.com/jdx/mise/releases/tag/v2025.4.5

> [mise-v2025.4.5-windows-arm64.zip](https://github.com/jdx/mise/releases/download/v2025.4.5/mise-v2025.4.5-windows-arm64.zip)
> 12.1 MB
> 14 hours ago
> [mise-v2025.4.5-windows-x64.zip](https://github.com/jdx/mise/releases/download/v2025.4.5/mise-v2025.4.5-windows-x64.zip)
> 12.8 MB
> 14 hours ago



