### PR TITLE
Fixing bug in tilt proto toml plugin

### DIFF
--- a/tilt/plugin.toml
+++ b/tilt/plugin.toml
@@ -19,5 +19,8 @@ checksum-file = "checksums.txt"
 [install]
 download-url = "https://github.com/tilt-dev/tilt/releases/download/v{version}/{download_file}"
 
+[install.arch]
+aarch64 = "arm64"
+
 [resolve]
 git-url = "https://github.com/tilt-dev/tilt"


### PR DESCRIPTION
Latest version of tilt will not install on macs with apple silicon. See asset section here: https://github.com/tilt-dev/tilt/releases/tag/v0.34.2 . Specifically, it looks like instead of aarch64 they use arm64.

> https://github.com/tilt-dev/tilt/releases/download/v0.34.2/tilt.0.34.2.mac.arm64.tar.gz

How did I test?
I configured proto to use this local toml file and installed `tilt = "0.34.2"`