### PR TITLE
changed aarch64 to arm64 for arm osx as per the tilt release

### DIFF
--- a/tilt/plugin.toml
+++ b/tilt/plugin.toml
@@ -19,5 +19,8 @@ checksum-file = "checksums.txt"
 [install]
 download-url = "https://github.com/tilt-dev/tilt/releases/download/v{version}/{download_file}"
 
+[install.arch]
+aarch64 = "arm64"
+
 [resolve]
 git-url = "https://github.com/tilt-dev/tilt"


### PR DESCRIPTION
These are the releases for tilt

```
checksums.txt
883 Bytes
last week
tilt.0.34.5.linux-alpine.arm64.tar.gz
28.6 MB
last week
tilt.0.34.5.linux-alpine.x86_64.tar.gz
31.2 MB
last week
tilt.0.34.5.linux.arm.tar.gz
37.1 MB
last week
tilt.0.34.5.linux.arm64.tar.gz
35.2 MB
last week
tilt.0.34.5.linux.x86_64.tar.gz
39.3 MB
last week
tilt.0.34.5.mac.arm64.tar.gz
31.5 MB
last week
tilt.0.34.5.mac.x86_64.tar.gz
33.3 MB
last week
tilt.0.34.5.web-assets.tar.gz
1.11 MB
last week
tilt.0.34.5.windows.x86_64.zip
31.9 MB
last week
Source code
(zip)
last week
Source code
(tar.gz)
```

currently mac is failing

```
Error: net::not_found

  × Unable to download file, the URL https://github.com/tilt-dev/tilt/releases/download/v0.34.5/
  │ tilt.0.34.5.mac.aarch64.tar.gz does not exist.
  ```
  
  After change
  
  ```
  proto install tilt

│ SUCCESS
│ Added tilt plugin to config /Users/ishansharma/projects/simplismart/simplismart-v2/product/.prototools


│ SUCCESS
│ tilt 0.34.5 has been installed to /Users/ishansharma/.proto/tools/tilt/0.34.5!
````
