### PR TITLE
fix: update macOS download file format to tar.gz

### DIFF
--- a/fzf/plugin.toml
+++ b/fzf/plugin.toml
@@ -9,7 +9,7 @@ download-file = "fzf-{version}-linux_{arch}.tar.gz"
 checksum-file = "fzf_{version}_checksums.txt"
 
 [platform.macos]
-download-file = "fzf-{version}-darwin_{arch}.zip"
+download-file = "fzf-{version}-darwin_{arch}.tar.gz"
 checksum-file = "fzf_{version}_checksums.txt"
 
 [platform.windows]


### PR DESCRIPTION
This PR updates the download-file extension to .tar.gz for the macos platform.

ref: https://github.com/junegunn/fzf/releases