### PR TITLE
fix(gh): correct exe-path for Windows platform

### DIFF
--- a/gh/plugin.toml
+++ b/gh/plugin.toml
@@ -15,7 +15,7 @@ download-file = "gh_{version}_macOS_{arch}.zip"
 checksum-file = "gh_{version}_checksums.txt"
 
 [platform.windows]
-exe-path = "gh_{version}_windows_{arch}/bin/gh.exe"
+exe-path = "bin/gh.exe"
 download-file = "gh_{version}_windows_{arch}.zip"
 checksum-file = "gh_{version}_checksums.txt"
 


### PR DESCRIPTION
## Summary

- Fix the `exe-path` for `[platform.windows]` in the gh plugin from `gh_{version}_windows_{arch}/bin/gh.exe` to `bin/gh.exe`
- The GitHub CLI Windows zip archives have **never** included a top-level directory prefix — the archive structure is flat (`LICENSE`, `bin/gh.exe`), unlike Linux (`.tar.gz`) and macOS (`.zip`) which do include the `gh_{version}_{os}_{arch}/` prefix

## Problem

Installing the gh CLI via proto on Windows fails with:

```
Error: proto::locate::missing_executable

  × Unable to find an executable for GitHub CLI, expected file
  │ ~/.proto/tools/gh/2.87.3/gh_2.87.3_windows_amd64/bin/gh.exe does not exist.
```

This happens because the plugin assumes the Windows zip has the same directory structure as Linux/macOS, but it does not. I verified multiple releases going back to v2.20.0 — the Windows zip has always been flat:

```
$ unzip -l gh_2.87.3_windows_amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     1089  2026-02-23 16:26   LICENSE
 38849520  2026-02-23 16:31   bin/gh.exe
```

While Linux and macOS archives include the prefix:

```
$ tar tzf gh_2.87.3_linux_amd64.tar.gz | head -3
gh_2.87.3_linux_amd64/LICENSE
gh_2.87.3_linux_amd64/share/man/man1/gh-agent-task-create.1
...
```

## Related

- Closes the Windows-specific aspect of #31 (which was fixed for macOS in #34 but not Windows)