### PR TITLE
fix(jq): add $ anchor to version-pattern to filter pre-release tags

### DIFF
--- a/jq/plugin.toml
+++ b/jq/plugin.toml
@@ -25,4 +25,4 @@ x86_64 = "amd64"
 
 [resolve]
 git-url = "https://github.com/jqlang/jq"
-version-pattern = "^jq-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)"
+version-pattern = "^jq-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"


### PR DESCRIPTION
## Problem

`proto outdated` incorrectly reports `1.8.2` as the latest version for jq, even though jq has never released `1.8.2`. The actual latest tag is `jq-1.8.2rc1` (a release candidate).

This causes `proto install jq` to fail with 404 when trying to download the non-existent release.

## Root Cause

The `version-pattern` regex lacks a `$` end-of-string anchor:

```toml
version-pattern = "^jq-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)"
```

When matching `jq-1.8.2rc1`, the regex partially matches `jq-1.8.2` and ignores the `rc1` suffix, extracting version `1.8.2` which does not exist.

## Fix

Add `$` anchor to ensure the regex matches the entire tag:

```toml
version-pattern = "^jq-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
```

## Verification

Before fix:
- `jq-1.8.2rc1` → extracted as `1.8.2` ❌
- `proto outdated` reports latest = `1.8.2`

After fix:
- `jq-1.8.2rc1` → no match ✅
- `jq-1.8.1` → extracted as `1.8.1` ✅
- `proto outdated` correctly reports latest = `1.8.1`
