### PR TITLE
ci: replace deprecated macos-12 with macos-15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: macos-12
+          - os: macos-15
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Problem

CI workflow is stuck on `macos-12` runner because GitHub has deprecated and removed the `macos-12` image.

- **Deprecation start:** 2024-10-07
- **Full removal:** 2024-12-03
- Ref: https://github.com/actions/runner-images/issues/10721

Jobs using this runner remain in `queued` state indefinitely.

Additionally, `macos-14` is also scheduled for deprecation on 2026-07-06 and fully unsupported by 2026-11-02, so upgrading to `macos-15` is the safest long-term choice.

## Fix

Replace `macos-12` with `macos-15` (the current stable Intel macOS runner with no deprecation plan).